### PR TITLE
Highlight overdue deadlines

### DIFF
--- a/assets/css/webdashboard.css
+++ b/assets/css/webdashboard.css
@@ -46,6 +46,11 @@ div#locales {
     width: 400px;
 }
 
+#main-content table .overdue {
+    color: red;
+    font-weight: bold;
+}
+
 #main-content table td,
 #main-content table th {
     border: 1px solid lightgray;

--- a/views/locale.php
+++ b/views/locale.php
@@ -48,13 +48,18 @@ foreach ($lang_files as $site => $tablo) {
 
         $critical = (isset($details['critical']) && $details['critical']) ? '<strong>Yes</strong>' : 'No';
 
+        $class = '';
         if (isset($details['deadline'])) {
-            $deadline = date('F d', (new \DateTime($details['deadline']))->getTimestamp());
+            $deadline_timestamp = (new \DateTime($details['deadline']))->getTimestamp();
+            $deadline = date('F d', $deadline_timestamp);
+            if ($deadline_timestamp < time()) {
+                $class = 'overdue';
+            }
         } else {
             $deadline = '--';
         }
 
-        $rows .= '     <td class="col3">' . $deadline  . '</td>';
+        $rows .= "     <td class=\"col3 $class\">" . $deadline  . '</td>';
         $rows .= '     <td class="col3">' . $critical  . '</td>';
         $rows .= '</tr>';
 


### PR DESCRIPTION
When a deadline is overdue, it displays the date in red. Maybe a bit flashy as is. We could also leave the date in black, and just add "(overdue)" after it. Up to you.
Or we can do nothing, but I thought it would be better for localizers to make a difference between what's overdue, and what's still doable on time.
