### PR TITLE
Restore missing </a> in locale view (team page link)

### DIFF
--- a/views/locale.php
+++ b/views/locale.php
@@ -9,7 +9,7 @@ $rss_status = <<<RSS
     </a>
 </p>
 <div id="locale">
-    <a href="http://wiki.mozilla.org/L10n:Teams:{$locale}">{$locale}
+    <a href="http://wiki.mozilla.org/L10n:Teams:{$locale}">{$locale}</a>
 RSS;
 if ($locamotion) {
     $rss_status .= '<img src="assets/images/locamotion.png" class="locamotion" />';


### PR DESCRIPTION
Error introduced in
https://github.com/pascalchevrel/webdashboard/commit/a2f0960cdf65f339460f982e1823e97a8222c658

Noticed this morning because the link was bleeding in the “Reminder” below the table.
