### PR TITLE
Fix bugs for -www locales, add hi-IN

### DIFF
--- a/classes/Webdashboard/Utils.php
+++ b/classes/Webdashboard/Utils.php
@@ -109,7 +109,8 @@ class Utils {
             'gl'        => 'Galician',
             'gu-IN'     => 'Gujarati',
             'he'        => 'Hebrew',
-            'hi-IN'     => 'Hindi (India)',
+            'hi-IN'     => 'hindi',
+            'hi-IN-www' => 'Hindi (India)',
             'hr'        => 'Croatian',
             'hu'        => 'Hungarian',
             'hy-AM'     => 'Armenian',
@@ -171,7 +172,8 @@ class Utils {
             'zu'        => 'Zulu',
             ];
 
-            return $locale . ' / ' . $locales[$locale];
+            // Eventually I need to remove -www to get the real locale code
+            return rtrim($locale, '-www') . ' / ' . $locales[$locale];
         }
 
         /**

--- a/models/locale.php
+++ b/models/locale.php
@@ -26,8 +26,8 @@ $lang_files = Json::fetch(LANG_CHECKER . "?locale={$locale}&json");
 $locamotion = Json::fetch(Utils::cacheUrl(LANG_CHECKER . '?action=listlocales&project=locamotion&json', 15*60));
 $locamotion = in_array($locale, $locamotion);
 
-// This is needed for Norwegians, having different names in Bugzilla products
-if (in_array($locale, ['nb-NO', 'nn-NO'])) {
+// This is needed for Norwegians and Hindi, having different names in Bugzilla products
+if (in_array($locale, ['hi-IN', 'nb-NO', 'nn-NO'])) {
     $localeweb = $locale . '-www';
 } else {
     $localeweb = $locale;


### PR DESCRIPTION
I noticed that hi-IN has the same issue of Norwegian, and found a not so nice bug that I introduced (query for mozilla.org was using "nb-NO-www" as locale code).
