### PR TITLE
Update list of locales for Bugzilla, move logic to getBugzillaLocaleField

### DIFF
--- a/classes/Webdashboard/Utils.php
+++ b/classes/Webdashboard/Utils.php
@@ -69,7 +69,7 @@ class Utils {
         return $url;
     }
 
-    public static function getBugzillaLocaleField($locale) {
+    public static function getBugzillaLocaleField($locale, $component = 'www') {
         $locales = [
             'ach'       => 'Acholi',
             'af'        => 'Afrikaans',
@@ -80,7 +80,8 @@ class Utils {
             'az'        => 'Azerbaijani',
             'be'        => 'Belarusian',
             'bg'        => 'Bulgarian',
-            'bn-BD'     => 'Bengali (Bangladesh)',
+            'bn-BD'     => 'Bengali',
+            'bn-BD-www' => 'Bengali (Bangladesh)',
             'bn-IN'     => 'Bengali (India)',
             'br'        => 'Breton',
             'bs'        => 'Bosnian',
@@ -90,12 +91,15 @@ class Utils {
             'cy'        => 'Welsh',
             'da'        => 'Danish',
             'de'        => 'German',
+            'dsb'       => 'Lower Sorbian',
             'el'        => 'Greek',
-            'en-GB'     => 'English (British)',
+            'en-GB'     => 'English (United Kingdom)',
+            'en-GB-www' => 'English (British)',
             'eo'        => 'Esperanto',
             'es-AR'     => 'Spanish (Argentina)',
             'es-CL'     => 'Spanish (Chile)',
-            'es-ES'     => 'Spanish (Spain)',
+            'es-ES'     => 'Spanish',
+            'es-ES-www' => 'Spanish (Spain)',
             'es-MX'     => 'Spanish (Mexico)',
             'et'        => 'Estonian',
             'eu'        => 'Basque',
@@ -104,14 +108,17 @@ class Utils {
             'fi'        => 'Finnish',
             'fr'        => 'French',
             'fy-NL'     => 'Frisian',
-            'ga-IE'     => 'Irish (Ireland)',
-            'gd'        => 'Gaelic (Scotland)',
+            'ga-IE'     => 'Irish',
+            'ga-IE-www' => 'Irish (Ireland)',
+            'gd'        => 'Scottish Gaelic',
+            'gd-www'    => 'Gaelic (Scotland)',
             'gl'        => 'Galician',
             'gu-IN'     => 'Gujarati',
             'he'        => 'Hebrew',
             'hi-IN'     => 'hindi',
             'hi-IN-www' => 'Hindi (India)',
             'hr'        => 'Croatian',
+            'hsb'       => 'Upper Sorbian',
             'hu'        => 'Hungarian',
             'hy-AM'     => 'Armenian',
             'id'        => 'Indonesian',
@@ -140,19 +147,24 @@ class Utils {
             'nl'        => 'Dutch',
             'nn-NO'     => 'Norwegian Nynorsk',
             'nn-NO-www' => 'Norwegian (Nynorsk)',
-            'nso'       => 'Northern Sotho',
-            'oc'        => 'Occitan (Lengadocian)',
+            'nso'       => 'Northern Sotho (Pedi)',
+            'nso-www'   => 'Northern Sotho',
+            'oc'        => 'Occitan',
+            'oc-www'    => 'Occitan (Lengadocian)',
             'or'        => 'Oriya',
             'pa-IN'     => 'Punjabi',
             'pl'        => 'Polish',
-            'pt-BR'     => 'Portuguese (Brazilian)',
-            'pt-PT'     => 'Portuguese (Portugal)',
+            'pt-BR'     => 'Portuguese (Brazil)',
+            'pt-BR-www' => 'Portuguese (Brazilian)',
+            'pt-PT'     => 'Portuguese',
+            'pt-PT-www' => 'Portuguese (Portugal)',
             'rm'        => 'Romansh',
             'ro'        => 'Romanian',
             'ru'        => 'Russian',
             'si'        => 'Sinhala',
             'sk'        => 'Slovak',
-            'sl'        => 'Slovenian',
+            'sl'        => 'Slovene',
+            'sl-www'    => 'Slovenian',
             'sq'        => 'Albanian',
             'sr'        => 'Serbian',
             'sv-SE'     => 'Swedish',
@@ -164,6 +176,7 @@ class Utils {
             'tr'        => 'Turkish',
             'uk'        => 'Ukrainian',
             'ur'        => 'Urdu',
+            'uz'        => 'Uzbek',
             'vi'        => 'Vietnamese',
             'wo'        => 'Wolof',
             'xh'        => 'Xhosa',
@@ -172,8 +185,12 @@ class Utils {
             'zu'        => 'Zulu',
             ];
 
-            // Eventually I need to remove -www to get the real locale code
-            return rtrim($locale, '-www') . ' / ' . $locales[$locale];
+            $localeweb = "{$locale}-www";
+            if ($component == 'www' && array_key_exists($localeweb, $locales)) {
+                return $locale . ' / ' . $locales[$localeweb];
+            }
+
+            return $locale . ' / ' . $locales[$locale];
         }
 
         /**

--- a/models/locale.php
+++ b/models/locale.php
@@ -26,19 +26,12 @@ $lang_files = Json::fetch(LANG_CHECKER . "?locale={$locale}&json");
 $locamotion = Json::fetch(Utils::cacheUrl(LANG_CHECKER . '?action=listlocales&project=locamotion&json', 15*60));
 $locamotion = in_array($locale, $locamotion);
 
-// This is needed for Norwegians and Hindi, having different names in Bugzilla products
-if (in_array($locale, ['hi-IN', 'nb-NO', 'nn-NO'])) {
-    $localeweb = $locale . '-www';
-} else {
-    $localeweb = $locale;
-}
-
 // all open bugs for a locale in the mozilla.org/l10n component
 $bugzilla_query_mozillaorg = 'https://bugzilla.mozilla.org/buglist.cgi?'
                            . 'f1=cf_locale'
                            . '&o1=equals'
                            . '&query_format=advanced'
-                           . '&v1=' . urlencode(Utils::getBugzillaLocaleField($localeweb))
+                           . '&v1=' . urlencode(Utils::getBugzillaLocaleField($locale))
                            . '&o2=equals'
                            . '&f2=component'
                            . '&v2=L10N'
@@ -58,7 +51,7 @@ $bugzilla_query_l10ncomponent = 'https://bugzilla.mozilla.org/buglist.cgi?'
                               . '&bug_status=NEW'
                               . '&bug_status=ASSIGNED'
                               . '&bug_status=REOPENED'
-                              . '&component=' . urlencode(Utils::getBugzillaLocaleField($locale))
+                              . '&component=' . urlencode(Utils::getBugzillaLocaleField($locale, 'l10n'))
                               . '&classification=Client%20Software'
                               . '&product=Mozilla%20Localizations';
 

--- a/templates/default.php
+++ b/templates/default.php
@@ -8,7 +8,11 @@
     <link href="./assets/css/webdashboard.css" rel="stylesheet">
     <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet">
     <link rel="icon" href="./assets/images/mozilla-l10n.png" type="image/png">
-    <?=$links?>
+    <?php
+        if (isset($links)) {
+            echo $links;
+        }
+    ?>
 </head>
 <body class="<?=$body_class?>">
     <div id="outer-wrapper">


### PR DESCRIPTION
I realized that the list of locales with different names between mozilla.org and Mozilla Localizations is much longer than I thought.

So, moving the logic inside the class to avoid having a different array to maintain, adding an optional parameter. The only other user of that function is json/index.php, behavior is not changed since the default component is 'www'.

Also removing one warning from logs ($links is defined only for projects)
