### PR TITLE
Add support for raw files

### DIFF
--- a/assets/css/webdashboard.css
+++ b/assets/css/webdashboard.css
@@ -51,6 +51,24 @@ div#locales {
     text-align: left;
 }
 
+span.rawstatus {
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+span.untranslated {
+    color: #ff5b52;
+}
+
+span.outdated {
+    color: #ffbd52;
+}
+
+span.missing_reference,
+span.missing_locale {
+    color: #82817f;
+}
+
 #main-content table .overdue {
     color: #f00;
     font-weight: bold;


### PR DESCRIPTION
This goes together with the [PR for langchecker](https://github.com/mozilla-l10n/langchecker/pull/173/files).

Only some file are added to the RSS feed or displayed in the main view:
- if they're untranslated or outdated.
- if they're missing and not optional.
