### PR TITLE
Add link to column headers in Projects, fix footer

### DIFF
--- a/assets/css/webdashboard.css
+++ b/assets/css/webdashboard.css
@@ -22,6 +22,19 @@ div#locales {
     width: 100%;
 }
 
+#colophon .footer-license {
+    width: 300px;
+}
+
+#colophon .footer-nav li {
+    float: left;
+    margin-right: 5px;
+}
+
+#colophon .footer-nav li.wrap::before {
+    content: " · ";
+}
+
 #main-content table {
     text-align: center;
     border-collapse: collapse;
@@ -35,6 +48,11 @@ div#locales {
 }
 
 #main-content table.results td {
+    padding: 10px 20px;
+    background-color: #FFF;
+}
+
+#main-content table.results th {
     padding: 10px 20px;
 }
 

--- a/templates/default.php
+++ b/templates/default.php
@@ -42,12 +42,12 @@
               </div>
 
               <div class="footer-license">
-                  <p>Except where otherwise <a href="http://www.mozilla.org/en-US/about/legal.html#site">noted</a>, content on this site is licensed under the <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution Share-Alike License v3.0</a> or any later version.</p>
+                  <p>Portions of this content are ©1998–<?php echo date("Y"); ?> by individual mozilla.org contributors. Content available under a <a href="https://www.mozilla.org/foundation/licensing/website-content/">Creative Commons license</a>.</p>
               </div>
 
               <ul class="footer-nav">
-                <li><a href="/privacy/">Privacy Policy</a></li>
-                <li><a href="http://mozilla.org/about/legal.html">Legal Notices</a></li>
+                <li><a href="https://www.mozilla.org/about/privacy/">Privacy</a></li>
+                <li class="wrap"><a href="https://www.mozilla.org/about/legal/">Legal</a></li>
               </ul>
           </div>
          </footer>

--- a/views/project.php
+++ b/views/project.php
@@ -4,7 +4,7 @@ namespace Webdashboard;
 $body_class = $body_class . ' project';
 $links = '<script language="javascript" type="text/javascript" src="./assets/js/sorttable.js"></script>';
 $content = "
-    <table class=\"table sortable\" id=\"project\">
+    <table class=\"table\" id=\"project\">
         <caption>L10n Project Dashboard ($project)</caption>
         <thead>
             <tr>
@@ -12,7 +12,8 @@ $content = "
 
 // Display columns name
 foreach ($pages as $page) {
-    $content .= '<td>' . $page['file'] . '</td>';
+    $status_url = LANG_CHECKER . '?locale=all&amp;website=' . $page['site'] . '&amp;file=' . $page['file'];
+    $content .= '<td><a href="' . $status_url . '" title="Open the status page for this file">' . $page['file'] . '</a></td>';
 }
 $content .= '
             </tr>
@@ -58,7 +59,7 @@ $content .= '</tbody>'
           . '</table>';
 
 // Display stats per page
-$content .= '<table class="results sortable">
+$content .= '<table class="results">
                 <thead>
                   <tr>
                     <th>Page</th><th>Completion</th>
@@ -75,8 +76,8 @@ foreach ($locale_done_per_page as $page => $locales) {
 }
 
 // Display global stats
-$content .= '<tr><td colspan="2" class="final">Total: ' . count($locale_done) . '/' . $total_locales . ' perfect locales (' . $perfect_locales_coverage . '%)</td></tr>'
-          . '<tr><td colspan="2">Average: ' . $average_nb_locales . '/' . $total_locales . ' perfect locales (' . $average_coverage . '%)</td></tr>'
+$content .= '<tr><th colspan="2" class="final">Total: ' . count($locale_done) . '/' . $total_locales . ' perfect locales (' . $perfect_locales_coverage . '%)</th></tr>'
+          . '<tr><th colspan="2">Average: ' . $average_nb_locales . '/' . $total_locales . ' perfect locales (' . $average_coverage . '%)</th></tr>'
           . '</tbody>'
           . '</table>'
           . '<p class="table_legend">Percentages between parenthesis express coverage of our l10n base.</p>';


### PR DESCRIPTION
- Make tables in Projects view non sortable, add link in column headers to individual status pages.
- Make aspect of the Results table more consistent with other tables (white background for data).
- Fix footer: update links and text to make it more similar to current mozilla.org.
