### PR TITLE
Project view: add summary table, button to toggle some locales (complete, locamotion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cache/*.cache
 composer.lock
 composer.phar
+config/settings.inc.php
 vendor

--- a/assets/css/webdashboard.css
+++ b/assets/css/webdashboard.css
@@ -41,6 +41,7 @@ div#locales {
     margin-bottom: 1em;
     background-color: rgba(255,255,255,0.4);
     min-width: 650px;
+    clear: both;
 }
 
 #main-content table.results {
@@ -68,13 +69,39 @@ div#locales {
     font-weight: bold;
 }
 
-#main-content table th {
+#main-content table.locales_summary th {
+    padding: 10px 20px;
+}
+
+#main-content table.locales_summary td {
+    padding: 10px 20px;
+    background-color: #FFF;
+    text-align: left;
+    max-width: 300px;
+    vertical-align: top;
+}
+
+#main-content table.locales_summary td.category {
     text-align: center;
 }
 
-#main-content table td.filename {
+table.locales_summary span.title {
+    display: block;
+    font-weight: bold;
+}
+
+table.locales_summary span.description {
+    display: block;
     font-size: 80%;
-    padding: 0 5px;
+}
+
+#main-content table.locales_summary td.summary_locales {
+    width: 300px;
+    text-align: left;
+}
+
+#main-content table th {
+    text-align: center;
 }
 
 #main-content table span.filename {
@@ -118,6 +145,10 @@ span.missing_locale {
 #main-content table td.missing {
     background-color: #ff5252;
     color: #ff5252;
+}
+
+#main-content table td.missing_strings {
+    background-color: #fff;
 }
 
 #main-content table td.inprogress {
@@ -173,9 +204,10 @@ span.missing_locale {
     background: rgba(255,255,255, 0.4);
 }
 
-.locamotion{
+.locamotion {
     vertical-align: middle;
-    margin-left: 12px;
+    margin-left: 6px;
+    margin-top: -3px;
 }
 
 .bugbox1 {
@@ -234,7 +266,13 @@ span.wp_untrans {
 #project caption {
     font-size: 30px;
     text-align: center;
-    margin-bottom: 20px;
+    margin: 20px 0;
+}
+
+#main-content #project th {
+    font-size: 14px;
+    font-weight: bold;
+    padding: 5px 10px;
 }
 
 #project tr td {
@@ -246,6 +284,34 @@ span.wp_untrans {
 #project tr td.locale {
     text-align: left;
     white-space: pre;
+    min-width: 70px;
+    line-height: 1.6em;
+}
+
+#project tfoot tr td{
+    font-size: 11px;
+}
+
+#project span.hidden_locales {
+    display: block;
+    font-size: 11px;
+}
+
+#hide_buttons button {
+    float: left;
+    margin-right: 10px;
+}
+
+#hidden_message {
+    font-weight: bold;
+    position: absolute;
+    top: 30px;
+    padding-left: 10px;
+}
+
+.hidden,
+.hidden_locale {
+    display: none;
 }
 
 @media only screen and (min-width: 760px) and (max-width: 1000px) {

--- a/assets/js/toggle.js
+++ b/assets/js/toggle.js
@@ -1,0 +1,43 @@
+
+function toggleLocales(className, buttonID) {
+    var localeList = document.getElementsByClassName(className);
+    var toggleButton = document.getElementById(buttonID);
+    var hideLocales;
+
+    if (localeList.length > 0) {
+        if (toggleButton.classList.contains('active')) {
+            // I need to restore elements' visibility
+            toggleButton.classList.remove('active');
+            hideLocales = false;
+        } else {
+            // I need to hide locales
+            toggleButton.classList.add('active');
+            hideLocales = true;
+        }
+
+        for (var i = 0; i < localeList.length; i ++) {
+            if (hideLocales === true) {
+                localeList[i].classList.add('hidden_locale');
+            } else {
+                localeList[i].classList.remove('hidden_locale');
+            }
+        }
+
+        // Display message with the number of hidden locales
+        var hiddenLocalesMessage = document.getElementById('hidden_message');
+        var hiddenElements = document.getElementsByClassName('hidden_locale');
+
+        if (hiddenElements.length === 0) {
+            hiddenLocalesMessage.classList.add('hidden');
+        } else {
+            if (hiddenElements.length === 1) {
+                hiddenLocalesMessage.innerHTML = '1 locale hidden';
+            } else {
+                hiddenLocalesMessage.innerHTML = hiddenElements.length +
+                                                 ' locales hidden';
+            }
+            hiddenLocalesMessage.classList.remove('hidden');
+        }
+
+    }
+}

--- a/data/project.php
+++ b/data/project.php
@@ -161,25 +161,48 @@ $snippets_dec14 = [
     ],
 ];
 
-$pages = [
+/*
+* Each project has a key name that will be used in the URL.
+* Value is an array with:
+* - pages: list of files
+* - title: text to be displayed in the project page as title
+* - summary: if we need to display the summary table with good/bad locales
+*/
+
+$projects = [
     'default' => [
-        [
-            'file'        => 'main.lang',
-            'description' => 'main.lang',
-            'site'        => 0,
-        ],
+        'pages'  =>
+            [
+                'file'        => 'main.lang',
+                'description' => 'main.lang',
+                'site'        => 0,
+            ],
+        'title'   => 'Default',
+        'summary' => true,
     ],
-    'firefox_os' => $firefox_os,
-    'firefox_os_all' => array_merge($firefox_os, $firefox_os_extra),
-    'firefox_usage' =>
-    [
-        [
-            'file'        => 'firefox/desktop/tips.lang',
-            'description' => 'Firefox Tips',
-            'site'        => 0,
-        ],
+    'firefox_os' => [
+        'pages'   => $firefox_os,
+        'title'   => 'Firefox OS',
+        'summary' => true,
     ],
-    'fx10'     => $fx10,
-    'fx10_all' => array_merge($fx10, $fx10_extra),
-    'snippets_dec14' => $snippets_dec14,
+    'firefox_os_all' => [
+        'pages'   => array_merge($firefox_os, $firefox_os_extra),
+        'title'   => 'Firefox OS Complete',
+        'summary' => true,
+    ],
+    'fx10' => [
+        'pages'   => $fx10,
+        'title'   => 'Firefox 10th Anniversary',
+        'summary' => true,
+    ],
+    'fx10_all' => [
+        'pages'   => array_merge($fx10, $fx10_extra),
+        'title'   => 'Firefox 10th Anniversary Complete',
+        'summary' => true,
+    ],
+    'snippets_dec14' => [
+        'pages'   => $snippets_dec14,
+        'title'   => 'Snippets December 2014',
+        'summary' => false,
+    ],
 ];


### PR DESCRIPTION
- Summary table uses a structure similar to the one already available on langchecker, just based on % instead of missing strings.
- Added a button to hide/show complete locales, locamotion locales
- Updated projects data structure: pretty title to display on project page, possibility to hide the new summary table on small projects like https://l10n.mozilla-community.org/webdashboard/?project=snippets_dec14
- Added local config file to .gitignore

At this point #31 should be obsolete.
