### PR TITLE
Sync list of supported locales with langchecker

### DIFF
--- a/data/locales.php
+++ b/data/locales.php
@@ -1,14 +1,15 @@
 <?php
 
 $locales = [
-    'ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-IN',
-    'bn-BD', 'br', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'dsb', 'el',
-    'eo', 'es-AR', 'es-ES', 'es-CL', 'es-MX', 'et', 'eu', 'fa', 'ff',
-    'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gu-IN', 'he', 'hi-IN',
-    'hr', 'hu', 'hy-AM', 'hsb', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'kn',
-    'km', 'ko', 'lij', 'lt', 'lv', 'mai', 'mk', 'ml', 'mr',
-    'ms', 'my', 'nb-NO', 'nl', 'nn-NO', 'oc', 'or', 'pa-IN',
-    'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'sat', 'si', 'sk', 'sl',
-    'son', 'sq', 'sr', 'sv-SE', 'ta', 'te', 'th', 'tr', 'uk',
-    'ur', 'uz', 'vi', 'xh', 'zh-CN', 'zh-TW', 'zu',
+    'ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
+    'bn-IN', 'bn-BD', 'br', 'bs', 'ca', 'cs', 'cy', 'da', 'de',
+    'dsb', 'el', 'en-GB', 'en-ZA', 'eo', 'es', 'es-AR', 'es-ES', 'es-CL',
+    'es-MX', 'et', 'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd',
+    'gl', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is',
+    'it', 'ja', 'ka', 'kk', 'kn', 'km', 'ko', 'lij', 'lt',
+    'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'nl', 'nn-NO',
+    'oc', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru',
+    'sat', 'si', 'sk', 'sl', 'son', 'sq', 'sr', 'sr-Latn', 'sv-SE',
+    'ta', 'te', 'th', 'tr', 'uk', 'ur', 'uz', 'vi', 'xh',
+    'zh-CN', 'zh-TW', 'zu',
 ];


### PR DESCRIPTION
Diff might result bigger than necessary.

Actual additions are only: en-GB, en-ZA, es, sr-Latn. I'm keeping them enabled since they have a few projects (ignoring mozilla.org) that might have sense to track.