### PR TITLE
Remove iOS from Spring Campaign dashboard

### DIFF
--- a/data/project.php
+++ b/data/project.php
@@ -222,11 +222,6 @@ $spring15 = [
         'site'        => 0,
     ],
     [
-        'file'        => 'firefox/ios.lang',
-        'description' => 'Firefox for iOS',
-        'site'        => 0,
-    ],
-    [
         'file'        => 'firefox/developer.lang',
         'description' => 'Developer Edition',
         'site'        => 0,


### PR DESCRIPTION
Clearly not part of the plan for June 2nd